### PR TITLE
add trace func ContextWithSpan

### DIFF
--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -49,6 +49,10 @@ func SpanFromContext(ctx context.Context) opentracing.Span {
 	return opentracing.SpanFromContext(ctx)
 }
 
+func ContextWithSpan(ctx context.Context, span opentracing.Span) context.Context {
+	return opentracing.ContextWithSpan(ctx, span)
+}
+
 // FromIncomingContext extract trace info from span
 func FromIncomingContext(ctx context.Context) opentracing.StartSpanOption {
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -49,6 +49,7 @@ func SpanFromContext(ctx context.Context) opentracing.Span {
 	return opentracing.SpanFromContext(ctx)
 }
 
+// ContextWithSpan return a new `context.Context` that holds a reference to the span
 func ContextWithSpan(ctx context.Context, span opentracing.Span) context.Context {
 	return opentracing.ContextWithSpan(ctx, span)
 }


### PR DESCRIPTION
old project use the func ContextWithSpan, it's stable and useful, so bring it back